### PR TITLE
Add glassmorphism navbar and NearSpace team modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,47 @@
 // src/App.jsx
+import { useCallback, useState } from 'react';
 import useApiData from './hooks/useApiData';
 import DataTable from './components/DataTable';
 import { Loader } from './components/ui/Loader';
 import { ErrorMessage } from './components/ui/ErrorMessage';
-import StarfieldBackground from "./components/ui/StarfieldBackground";
+import StarfieldBackground from './components/ui/StarfieldBackground';
+import Navbar from './components/Navbar';
+import TeamModal from './components/TeamModal';
 
 function App() {
   const { data, isLoading, error } = useApiData('YOUR_API_ENDPOINT_HERE');
+  const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
+
+  const handleOpenTeamModal = useCallback(() => setIsTeamModalOpen(true), []);
+  const handleCloseTeamModal = useCallback(() => setIsTeamModalOpen(false), []);
+
+  const shouldHideMainContent = isTeamModalOpen;
 
   return (
-      
     <main className="min-h-screen p-4 md:p-8 font-sans relative z-10">
       <StarfieldBackground />
       <div className="container mx-auto">
-        <header className="my-10 ">
-          <h1 className="text-5xl font-bold text-white text-center">Exoplanet Observatory</h1>
-          <p className="text-accent-light text-center">Data from the Transiting Exoplanet Survey Satellite (TESS)</p>
+        <header className={`my-10 transition-all duration-300 ${shouldHideMainContent ? 'hidden' : 'block'}`}>
+          <div className="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-white/10 p-8 text-center shadow-2xl shadow-black/30 backdrop-blur-2xl">
+            <h1 className="text-5xl font-bold text-white">Exoplanet Observatory</h1>
+            <p className="mt-3 text-accent-light">
+              Data from the Transiting Exoplanet Survey Satellite (TESS)
+            </p>
+          </div>
         </header>
 
-        {isLoading && <Loader />}
-        {error && <ErrorMessage message={error} />}
-        {!isLoading && !error && data.length > 0 && <DataTable data={data} />}
+        <Navbar onNearSpaceTeamClick={handleOpenTeamModal} isHidden={shouldHideMainContent} />
+
+        {!shouldHideMainContent && (
+          <div className="space-y-6">
+            {isLoading && <Loader />}
+            {error && <ErrorMessage message={error} />}
+            {!isLoading && !error && data.length > 0 && <DataTable data={data} />}
+          </div>
+        )}
       </div>
+
+      <TeamModal isOpen={isTeamModalOpen} onClose={handleCloseTeamModal} />
     </main>
   );
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,23 @@
+const buttonBaseClasses =
+  'px-5 py-2 rounded-full border border-white/10 bg-white/10 text-sm font-medium text-white/90 backdrop-blur transition-all duration-300 hover:border-accent-cyan hover:text-accent-cyan hover:shadow-[0_0_25px_rgba(34,211,238,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 focus-visible:ring-offset-2 focus-visible:ring-offset-space-dark';
+
+const Navbar = ({ onNearSpaceTeamClick, isHidden = false }) => {
+  if (isHidden) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="NearSpace secondary navigation" className="mb-10">
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-center gap-4 rounded-full border border-white/10 bg-white/10 px-6 py-3 backdrop-blur-xl shadow-lg shadow-black/20">
+        <button type="button" className={buttonBaseClasses}>
+          Exoplanet Detection with AI
+        </button>
+        <button type="button" onClick={onNearSpaceTeamClick} className={buttonBaseClasses}>
+          NearSpace Team
+        </button>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/components/TeamMemberCard.jsx
+++ b/src/components/TeamMemberCard.jsx
@@ -1,0 +1,40 @@
+import { FaGithub, FaLinkedin } from 'react-icons/fa6';
+
+const iconButtonClasses =
+  'inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white/80 transition-colors duration-300 hover:text-accent-cyan hover:border-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 focus-visible:ring-offset-2 focus-visible:ring-offset-space-dark';
+
+const TeamMemberCard = ({ member }) => {
+  const { name, photoUrl, profession, bio, socials } = member;
+
+  return (
+    <article className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/20 backdrop-blur-2xl transition-transform duration-300 hover:-translate-y-1">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+        <img
+          src={photoUrl}
+          alt={`Retrato de ${name}`}
+          className="h-24 w-24 flex-shrink-0 rounded-2xl border border-white/20 object-cover shadow-lg shadow-black/30"
+          loading="lazy"
+        />
+        <div className="flex-1">
+          <h3 className="text-xl font-semibold text-white">{name}</h3>
+          <p className="text-sm uppercase tracking-widest text-accent-light/80">{profession}</p>
+          <p className="mt-3 text-sm text-slate-100/90">{bio}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        {socials?.github && (
+          <a href={socials.github} target="_blank" rel="noopener noreferrer" className={iconButtonClasses} aria-label={`Abrir GitHub de ${name}`}>
+            <FaGithub className="text-lg" />
+          </a>
+        )}
+        {socials?.linkedin && (
+          <a href={socials.linkedin} target="_blank" rel="noopener noreferrer" className={iconButtonClasses} aria-label={`Abrir LinkedIn de ${name}`}>
+            <FaLinkedin className="text-lg" />
+          </a>
+        )}
+      </div>
+    </article>
+  );
+};
+
+export default TeamMemberCard;

--- a/src/components/TeamModal.jsx
+++ b/src/components/TeamModal.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { IoClose } from 'react-icons/io5';
+import { HiOutlineMapPin } from 'react-icons/hi2';
+import TeamMemberCard from './TeamMemberCard';
+import { Loader } from './ui/Loader';
+
+const TeamModal = ({ isOpen, onClose }) => {
+  const [teamData, setTeamData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoading(true);
+    setHasError(false);
+
+    import('../services/team_data.json')
+      .then((module) => {
+        if (isMounted) {
+          setTeamData(module.default);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setHasError(true);
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="team-modal-title"
+    >
+      <div className="absolute inset-0 bg-slate-950/70 backdrop-blur-2xl" />
+
+      <div className="relative z-10 w-full max-w-4xl overflow-hidden rounded-3xl border border-white/10 bg-white/10 shadow-2xl shadow-black/30 backdrop-blur-3xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white/80 transition-colors duration-300 hover:text-accent-cyan hover:border-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 focus-visible:ring-offset-2 focus-visible:ring-offset-space-dark"
+          aria-label="Cerrar modal de NearSpace Team"
+        >
+          <IoClose className="text-2xl" />
+        </button>
+
+        <div className="max-h-[80vh] overflow-y-auto px-6 py-10 sm:px-10">
+          {isLoading && (
+            <div className="flex justify-center py-10">
+              <Loader />
+            </div>
+          )}
+
+          {!isLoading && hasError && (
+            <p className="text-center text-base text-red-200">
+              Hubo un problema al cargar la información del equipo. Intenta nuevamente.
+            </p>
+          )}
+
+          {!isLoading && !hasError && teamData && (
+            <div className="space-y-6 text-white">
+              <div className="space-y-4 text-center">
+                <h2 id="team-modal-title" className="text-3xl font-bold tracking-tight text-white">
+                  {teamData.teamName}
+                </h2>
+                <p className="mx-auto max-w-2xl text-base text-slate-100/80">
+                  {teamData.description}
+                </p>
+                <div className="flex items-center justify-center gap-2 text-sm text-accent-light">
+                  <HiOutlineMapPin className="text-lg text-accent-cyan" aria-hidden="true" />
+                  <span>{teamData.location}</span>
+                </div>
+              </div>
+
+              <div className="grid gap-6">
+                {teamData.members.map((member) => (
+                  <TeamMemberCard key={member.id} member={member} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeamModal;

--- a/src/services/team_data.json
+++ b/src/services/team_data.json
@@ -1,29 +1,39 @@
-[
-  {
-    "id": 1,
-    "name": "Alex Riveira",
-    "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=AR",
-    "role": "Lead Astrophysicist & Data Scientist",
-    "age": 34,
-    "email": "alex.r@nearspace.dev",
-    "aspirations": "Descubrir un exoplaneta análogo a la Tierra y desarrollar IA que pueda predecir zonas habitables en la galaxia."
-  },
-  {
-    "id": 2,
-    "name": "Beatriz Vargas",
-    "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=BV",
-    "role": "Senior Software Engineer & AI Specialist",
-    "age": 29,
-    "email": "beatriz.v@nearspace.dev",
-    "aspirations": "Construir sistemas autónomos para el análisis de datos telescópicos y liderar el desarrollo del próximo gran observatorio virtual."
-  },
-  {
-    "id": 3,
-    "name": "Carlos Mendoza",
-    "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=CM",
-    "role": "UI/UX Designer & Frontend Developer",
-    "age": 31,
-    "email": "carlos.m@nearspace.dev",
-    "aspirations": "Crear las interfaces más intuitivas y bellas para la visualización de datos científicos complejos, haciendo la ciencia accesible para todos."
-  }
-]
+{
+  "teamName": "NearSpace Team",
+  "description": "Somos un grupo multidisciplinario apasionado por la exploración espacial, la ciencia de datos y el diseño de experiencias que acerquen la astronomía a todas las personas.",
+  "location": "Barranquilla, Colombia",
+  "members": [
+    {
+      "id": 1,
+      "name": "Alex Riveira",
+      "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=AR",
+      "profession": "Lead Astrophysicist & Data Scientist",
+      "bio": "Especialista en dinámica orbital y modelado de atmósferas exoplanetarias. Lidera la integración de IA para acelerar el descubrimiento de planetas habitables.",
+      "socials": {
+        "github": "https://github.com/alex-riveira",
+        "linkedin": "https://www.linkedin.com/in/alex-riveira/"
+      }
+    },
+    {
+      "id": 2,
+      "name": "Beatriz Vargas",
+      "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=BV",
+      "profession": "Senior Software Engineer & AI Specialist",
+      "bio": "Diseña pipelines de visión computacional para telescopios automatizados y dirige la arquitectura de servicios que permiten el análisis en tiempo real.",
+      "socials": {
+        "github": "https://github.com/beatriz-vargas",
+        "linkedin": "https://www.linkedin.com/in/beatriz-vargas/"
+      }
+    },
+    {
+      "id": 3,
+      "name": "Carlos Mendoza",
+      "photoUrl": "https://placehold.co/150x150/1e293b/94a3b8?text=CM",
+      "profession": "UI/UX Designer & Frontend Developer",
+      "bio": "Transforma datos científicos complejos en interfaces inmersivas. Lidera la narrativa visual del observatorio virtual NearSpace.",
+      "socials": {
+        "linkedin": "https://www.linkedin.com/in/carlos-mendoza-uiux/"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a glassmorphism secondary navbar with themed call-to-action buttons beneath the main header
- introduce a NearSpace Team modal that loads local JSON data, hides the main view, and showcases team details with blur overlay
- create reusable team member cards and enrich the team data structure with descriptions and social links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29f604c008330ba9af6c37472605a